### PR TITLE
Add query for images depicting rainbows

### DIFF
--- a/datenpumpe-server/queries.php
+++ b/datenpumpe-server/queries.php
@@ -768,4 +768,18 @@ SELECT ?event ?eventLabel ?coordinates ?layer WHERE {
 SPARQL
   ],
 
+  [
+    'type' => 'images',
+    'title' => 'Welche Gemälde zeigen Regenbogen?',
+    'query' => <<<SPARQL
+SELECT ?painting ?paintingLabel ?painter ?painterLabel ?image WHERE {
+  ?painting wdt:P180 wd:Q1052;
+            wdt:P170 ?painter;
+            wdt:P18 ?image.
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}
+ORDER BY MD5(CONCAT(STR(NOW()), STR(?flag)))
+SPARQL
+  ],
+
 ];


### PR DESCRIPTION
Apparently, rainbows are going to be relevant for the Lange Nacht der Wissenschaften, so it’s nice to have a related query.