### PR TITLE
Translate queries into English

### DIFF
--- a/datenpumpe-server/queries.php
+++ b/datenpumpe-server/queries.php
@@ -16,7 +16,7 @@ $queries = [
 
   [
     'type' => 'table',
-    'title' => 'Wieviele Päpste hatten wieviele Kinder?',
+    'title' => 'How many popes had how many children?',
     'query' => <<<SPARQL
 SELECT ?Papst (YEAR(?date) AS ?geboren) (COUNT(?child) as ?Kinder) WHERE {
   ?child wdt:P22 ?father.
@@ -25,7 +25,7 @@ SELECT ?Papst (YEAR(?date) AS ?geboren) (COUNT(?child) as ?Kinder) WHERE {
   wdt:P569 ?date.
   OPTIONAL { ?father wdt:P18 ?picture. }
   ?father rdfs:label ?Papst.
-  FILTER(LANG(?Papst) = 'de').
+  FILTER(LANG(?Papst) = 'en').
 }
 GROUP BY ?Papst ?date
 ORDER BY DESC(?Kinder) ?Papst
@@ -35,7 +35,7 @@ SPARQL
 
   [
     'type' => 'images',
-    'title' => 'Welche Nationalflaggen zeigen Sterne?',
+    'title' => 'Which national flags show stars?',
     'query' => <<<SPARQL
 SELECT DISTINCT ?flag ?flagLabel (MIN(?images) AS ?image) WHERE {
   ?flag wdt:P31/wdt:P279* wd:Q186516;
@@ -43,7 +43,7 @@ SELECT DISTINCT ?flag ?flagLabel (MIN(?images) AS ?image) WHERE {
   ?flag wdt:P18 ?images.
   VALUES ?astronomical { wd:Q8928 wd:Q523 } ?depicted wdt:P31?/wdt:P279* ?astronomical.
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "de".
+    bd:serviceParam wikibase:language "en".
     ?flag rdfs:label ?flagLabel.
     ?depicted rdfs:label ?depictedLabel.
   }
@@ -56,7 +56,7 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Nur 12 internationale Flughäfen sind nach Frauen benannt',
+    'title' => 'Only 25 international airports are named after women',
     'query' => <<<SPARQL
 SELECT ?airport ?airportLabel ?location ?person ?personLabel (?gender AS ?layer) WHERE {
   ?airport wdt:P31/wdt:P279* wd:Q1248784;
@@ -79,7 +79,7 @@ SELECT ?airport ?airportLabel ?location ?person ?personLabel (?gender AS ?layer)
     BIND("other"@en AS ?other)
   }
   BIND(COALESCE(?female, ?male, ?other, "unknown"@en) AS ?gender)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 SPARQL
   ],
@@ -87,7 +87,7 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Nach Frauen benannte Hochschulen',
+    'title' => 'Higher education institutions named after women',
     'query' => <<<SPARQL
 SELECT ?airport ?airportLabel ?location ?person ?personLabel (?gender AS ?layer) WHERE {
   ?airport wdt:P31/wdt:P279* wd:Q38723;
@@ -110,7 +110,7 @@ SELECT ?airport ?airportLabel ?location ?person ?personLabel (?gender AS ?layer)
     BIND("other"@en AS ?other)
   }
   BIND(COALESCE(?female, ?male, ?other, "unknown"@en) AS ?gender)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 SPARQL
   ],
@@ -118,7 +118,7 @@ SPARQL
 
   [
     'type' => 'embed',
-    'title' => 'Meistvererbte Berufe',
+    'title' => 'Most inherited professions',
     'query' => <<<SPARQL
 #defaultView:BubbleChart
 SELECT ?occupation ?occupationLabel ?count WITH {
@@ -134,7 +134,7 @@ SELECT ?occupation ?occupationLabel ?count WITH {
   GROUP BY ?occupation ?occupationLabel
 } AS %results WHERE {
   INCLUDE %results  .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 SPARQL
   ],
@@ -142,7 +142,7 @@ SPARQL
 
   [
     'type' => 'images',
-    'title' => 'Auswahl früher Kunst von Frauen',
+    'title' => 'Selection of early women’s art',
     'query' => <<<SPARQL
 #defaultView:ImageGrid
 SELECT ?image ?artistLabel ?artLabel ?date WHERE {
@@ -158,7 +158,7 @@ SELECT ?image ?artistLabel ?artLabel ?date WHERE {
     ORDER BY ASC(?date)
     LIMIT 20
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 ORDER BY MD5(CONCAT(STR(NOW()), STR(?art))) # simulate random order – ORDER BY RAND() doesn’t have the desired effect
 LIMIT 20
@@ -216,7 +216,7 @@ SPARQL
 
   [
     'type' => 'singleValue',
-    'title' => 'Wie alt sind Mitglieder des 20. Bundestags durchschnittlich?',
+    'title' => 'How old are members of the 20th Bundestag on average?',
     'query' => <<<SPARQL
 SELECT (AVG(?age) AS ?avgAge) WHERE {
 ?mdb wdt:P31 wd:Q5;
@@ -233,7 +233,7 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Sprachverteilung in der Schweiz',
+    'title' => 'Language distribution in Switzerland',
     'query' => <<<SPARQL
 #defaultView:Map
   SELECT ?item (SAMPLE(?title) AS ?itemLabel) (SAMPLE(?location) AS ?location) (SAMPLE(?language) AS ?layer)
@@ -274,7 +274,7 @@ SPARQL
 
   [
     'type' => 'embed',
-    'title' => 'Anteil von Frauen und Johns im britischen Parlament',
+    'title' => 'Number of women and Johns in British parliaments',
     'query' => <<<SPARQL
 # UK parliaments with count of Johns and count of women
 #defaultView:LineChart
@@ -328,7 +328,7 @@ SPARQL
 
   [
     'type' => 'table',
-    'title' => 'Frauenanteil in fiktiven Universen',
+    'title' => 'Ratio of female characters per fictional universe',
     'query' => <<<SPARQL
 # ratio of female characters per fictional universe
 # (assuming that any item with “from fictional universe” and “sex or gender” is a fictional character)
@@ -344,7 +344,7 @@ SELECT ?universeLabel (?percentString AS ?Anteil) (?females AS ?Frauen) (?total 
   BIND(?females/?total AS ?ratio)
   BIND(100*?ratio AS ?percent)
   BIND(CONCAT(SUBSTR(STR(?percent), 1, 5), "%") AS ?percentString)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 ORDER BY DESC(?total)
 LIMIT 20
@@ -354,7 +354,7 @@ SPARQL
 
   [
     'type' => 'table',
-    'title' => 'Daten zu bekannten Katzen',
+    'title' => 'Data about famous cats',
     'query' => <<<SPARQL
 SELECT ?cat ?catLabel ?catDescription (YEAR(?date) as ?born) (GROUP_CONCAT(?ownerLabel; SEPARATOR=", ") AS ?owner)
 WHERE {
@@ -363,7 +363,7 @@ WHERE {
   ?cat wdt:P127 ?ownerItem.
   ?ownerItem rdfs:label ?ownerLabel.
   FILTER(LANG(?ownerLabel) = 'en').
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
 }
 GROUP BY ?cat ?catLabel ?catDescription ?date
 ORDER BY MD5(CONCAT(STR(NOW()), STR(?item)))
@@ -374,7 +374,7 @@ SPARQL
 
   [
     'type' => 'table',
-    'title' => 'Welche großen Städte liegen am tiefsten?',
+    'title' => 'Which big cities are located lowest on Earth?',
     'query' => <<<SPARQL
 SELECT ?cityLabel ?countryLabel ?altitude ?population WHERE
 {
@@ -382,7 +382,7 @@ SELECT ?cityLabel ?countryLabel ?altitude ?population WHERE
     wdt:P2044 ?altitude ;
     wdt:P17 ?country ;
     wdt:P1082 ?population .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
 }
 ORDER BY ?altitude ?cityLabel
 LIMIT 19
@@ -392,7 +392,7 @@ SPARQL
 
   [
     'type' => 'table',
-    'title' => 'Welche großen Städte liegen am höchsten?',
+    'title' => 'Which big cities are located highest on Earth?',
     'query' => <<<SPARQL
 SELECT ?cityLabel ?countryLabel ?altitude ?population WHERE
 {
@@ -400,7 +400,7 @@ SELECT ?cityLabel ?countryLabel ?altitude ?population WHERE
     wdt:P2044 ?altitude ;
     wdt:P17 ?country ;
     wdt:P1082 ?population .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
 }
 ORDER BY DESC(?altitude) ?cityLabel
 LIMIT 19
@@ -410,7 +410,7 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Kohlekraftwerke in Deutschland',
+    'title' => 'Coal power plants in Germany',
     'query' => <<<SPARQL
 #defaultView:Map
 SELECT DISTINCT ?item ?itemLabel ?image ?coor
@@ -420,7 +420,7 @@ SELECT DISTINCT ?item ?itemLabel ?image ?coor
       wdt:P625 ?coor.
   FILTER NOT EXISTS { ?item wdt:P576 ?closed. }
   FILTER NOT EXISTS { ?item wdt:P582 ?enddate. }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 SPARQL
   ],
@@ -428,7 +428,7 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Offshore-Windparks in Europa',
+    'title' => 'Offshore wind farms in Europe',
     'query' => <<<SPARQL
 #defaultView:Map
 SELECT DISTINCT ?item ?coor
@@ -449,7 +449,7 @@ SPARQL
   /**
   [
     'type' => 'embed',
-    'title' => 'Tragezeiten von Säugetieren',
+    'title' => 'Gestation periods of mammals',
     'query' => <<<SPARQL
 # Average gestation period of genera, color-coded by order
 #defaultView:BubbleChart
@@ -457,7 +457,7 @@ SPARQL
 WHERE
 {
   {
-    BIND("[AUTO_LANGUAGE]" AS ?language)
+    BIND("en" AS ?language)
     # find species with gestation period normalized to seconds
     ?species p:P3063/psn:P3063/wikibase:quantityAmount ?periodSeconds.
   # convert to days
@@ -474,7 +474,7 @@ WHERE
     ?genus rdfs:label ?genusLabel.
     FILTER(LANG(?genusLabel) = ?language)
     }
-    BIND(COALESCE(?trivialName, ?genusLabel, "<kein Name>"@de) AS ?label)
+    BIND(COALESCE(?trivialName, ?genusLabel, "<no name>"@en) AS ?label)
     # find order
     ?genus wdt:P171* ?order.
     ?order wdt:P105 wd:Q36602.
@@ -485,11 +485,11 @@ WHERE
   {
     # add scale
     VALUES (?genus ?period ?label) {
-    (wd:Q23387 7 "Woche"@de)
-      (wd:Q5151 30.436875 "Monat"@de)
-      (wd:Q1643308 91.310625 "3 Monate"@de)
-      (wd:Q2269240 182.62125 "6 Monate"@de)
-      (wd:Q577 365.2425 "Jahr"@de)
+    (wd:Q23387 7 "week"@en)
+      (wd:Q5151 30.436875 "month"@en)
+      (wd:Q1643308 91.310625 "3 months"@en)
+      (wd:Q2269240 182.62125 "6 months"@en)
+      (wd:Q577 365.2425 "year"@en)
     }
     BIND("CCCCCC" AS ?rgb)
   }
@@ -501,7 +501,7 @@ SPARQL
 
   [
     'type' => 'embed',
-    'title' => 'Kinder von Dschingis Khan',
+    'title' => 'Genghis Khan\'s children',
     'query' => <<<SPARQL
 #Children of Genghis Khan
 #defaultView:Graph
@@ -521,7 +521,7 @@ SELECT ?item ?itemLabel ?pic ?linkTo
   }
   OPTIONAL { ?item wdt:P40 ?linkTo }
   OPTIONAL { ?item wdt:P18 ?pic }
-  SERVICE wikibase:label {bd:serviceParam wikibase:language "de,en" }
+  SERVICE wikibase:label {bd:serviceParam wikibase:language "en" }
 }
 SPARQL
   ],
@@ -529,14 +529,14 @@ SPARQL
 
   [
     'type' => 'images',
-    'title' => 'Benannt nach Nelson Mandela',
+    'title' => 'Named after Nelson Mandela',
     'query' => <<<SPARQL
 SELECT ?label ?image ?loc WHERE {
   ?item wdt:P138 wd:Q8023.
   ?item wdt:P18 ?image.
   ?item wdt:P131 ?location.
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "de,en" . 
+    bd:serviceParam wikibase:language "en" . 
     ?item rdfs:label ?label.
     ?location rdfs:label ?loc.
   }
@@ -548,7 +548,7 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Wo wurden Raumfahrerinnen und Raumfahrer geboren?',
+    'title' => 'Where were astronauts born?',
     'query' => <<<SPARQL
 SELECT ?astronaut ?coord (?genderlabel AS ?layer) WHERE {
   ?astronaut ?x1 wd:Q11631;
@@ -557,7 +557,7 @@ SELECT ?astronaut ?coord (?genderlabel AS ?layer) WHERE {
   wdt:P19 ?birthplace.
   ?birthplace wdt:P625 ?coord.
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "de,en" . 
+    bd:serviceParam wikibase:language "en" . 
     ?gender rdfs:label ?genderlabel.
   }
 }
@@ -568,7 +568,7 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'U-Bahnhöfe in Berlin',
+    'title' => 'U-Bahn stations in Berlin',
     'query' => <<<SPARQL
   SELECT ?coord (?label AS ?layer)
 WHERE {
@@ -577,7 +577,7 @@ WHERE {
           wdt:P81 ?line;
           wdt:P625 ?coord.
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "de,en" . 
+    bd:serviceParam wikibase:language "en,de" . 
     ?line rdfs:label ?label.
   }
 }
@@ -588,14 +588,14 @@ SPARQL
 
   [
     'type' => 'embed',
-    'title' => 'Anzahl der Bahnlinien',
+    'title' => 'Number of train lines',
     'query' => <<<SPARQL
 #defaultView:BubbleChart
 SELECT ?country ?countryLabel (COUNT(?station) AS ?stations)
 WHERE {
   ?station wdt:P31/wdt:P279* wd:Q15141321;
              wdt:P17 ?country;
-    SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],de" }
+    SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
 }
 GROUP BY ?country ?countryLabel
 SPARQL
@@ -604,7 +604,7 @@ SPARQL
 
   [
     'type' => 'singleValue',
-    'title' => 'Anzahl der Tierarten in Wikidata',
+    'title' => 'Number of species in Wikidata',
     'query' => <<<SPARQL
 SELECT (COUNT(?item) as ?count)
 WHERE {
@@ -616,7 +616,7 @@ SPARQL
 
   [
     'type' => 'singleValue',
-    'title' => 'Anzahl der Personen in Wikidata',
+    'title' => 'Number of people in Wikidata',
     'query' => <<<SPARQL
 SELECT (COUNT(?item) as ?count)
 WHERE {
@@ -628,14 +628,14 @@ SPARQL
 
   [
     'type' => 'images',
-    'title' => 'Benannt nach Nelson Mandela',
+    'title' => 'named after Nelson Mandela',
     'query' => <<<SPARQL
 SELECT ?label ?image ?loc WHERE {
   ?item wdt:P138 wd:Q8023.
   ?item wdt:P18 ?image.
   ?item wdt:P131 ?location.
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "de,en" . 
+    bd:serviceParam wikibase:language "en" . 
     ?item rdfs:label ?label.
     ?location rdfs:label ?loc.
   }
@@ -647,7 +647,7 @@ SPARQL
 
   [
     'type' => 'embed',
-    'title' => 'Herkunft von Nobelpreisträgern',
+    'title' => 'origin of Nobel Prize winners',
     'query' => <<<SPARQL
 #defaultView:BubbleChart
 SELECT ?CountryLabel (COUNT(?Person) AS ?Preisträger)
@@ -658,7 +658,7 @@ WHERE
           wdt:P19 ?Place .
   ?Place wdt:P17 ?Country .
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
+    bd:serviceParam wikibase:language "en" .
   }
 }
 GROUP BY ?CountryLabel
@@ -669,13 +669,13 @@ SPARQL
 
   [
     'type' => 'images',
-    'title' => 'Gemälde im Louvre',
+    'title' => 'paintings in the Louvre',
     'query' => <<<SPARQL
 SELECT ?label ?image WHERE {
   ?item wdt:P195 wd:Q3044768 .
   ?item wdt:P18 ?image .
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "de,en" . 
+    bd:serviceParam wikibase:language "en" . 
     ?item rdfs:label ?label .
   }
 }
@@ -686,7 +686,7 @@ SPARQL
 
   [
     'type' => 'embed',
-    'title' => 'Zeitleiste der Raumsonden',
+    'title' => 'Timeline of space probes',
     'query' => <<<SPARQL
 #defaultView:Timeline
   SELECT ?image ?launchdate ?itemLabel
@@ -695,7 +695,7 @@ SPARQL
   ?item wdt:P31 wd:Q26529 .
    ?item wdt:P619 ?launchdate .
   OPTIONAL { ?item wdt:P18 ?image }
-   SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en". }
+   SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 SPARQL
   ],
@@ -703,14 +703,14 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Steckdosentypen weltweit',
+    'title' => 'Electrical socket types around the world',
     'query' => <<<SPARQL
 SELECT ?geoshape ?coord (?plugLabel AS ?layer) WHERE {
   ?country wdt:P2853 ?plug ;
            wdt:P3896 ?geoshape ;
            wdt:P625 ?coord .
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "de,en" .
+    bd:serviceParam wikibase:language "en" .
     ?plug rdfs:label ?plugLabel.
   }
 }
@@ -721,7 +721,7 @@ SPARQL
 
   [
     'type' => 'embed',
-    'title' => 'Länge von Filmen nach Datum',
+    'title' => 'Duration of films over time',
     'query' => <<<SPARQL
 #defaultView:LineChart
 SELECT ?year (AVG(?durationInMinutes) AS ?avgDurationInMinutes) ?genreLabel WHERE {
@@ -741,7 +741,7 @@ SELECT ?year (AVG(?durationInMinutes) AS ?avgDurationInMinutes) ?genreLabel WHER
   FILTER(?durationInMinutes < 60*24) # I take the editorial liberty to exclude these films (some stupidly long documentaries), because they just absurdly skew the averages
   BIND(STR(YEAR(?date)) AS ?year)
   BIND(?durationInSeconds/60 AS ?durationInMinutes)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 GROUP BY ?year ?genreLabel
 HAVING(COUNT(DISTINCT ?film) >= 10)
@@ -752,17 +752,17 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Erdbeben und Kernkraftwerke',
+    'title' => 'Earthquakes and nuclear power stations',
     'query' => <<<SPARQL
 SELECT ?event ?eventLabel ?coordinates ?layer WHERE {
   {
     ?event wdt:P31/wdt:P279* wd:Q7944;
                 wdt:P625 ?coordinates.
-    BIND("Erdbeben"@de AS ?layer)
+    BIND("earthquake"@en AS ?layer)
   } UNION {
     ?event wdt:P31/wdt:P279* wd:Q134447;
            wdt:P625 ?coordinates.
-    BIND("Kernkraftwerk"@de AS ?layer)
+    BIND("nuclear power station"@en AS ?layer)
   }
 }
 SPARQL


### PR DESCRIPTION
For the [quiz at re:publica 2023][1] – it probably won’t use the real Datenpumpe interface live, but this should still be useful for preparation.

I also updated the number of results for airports named after women, and corrected the title of the “number of species” query – it’s actually counting all species, whether animal plant or other, and IIRC the plants actually significantly outnumber the animals.

I’ve left the three queries specific to German municipalities as they are, I don’t think it makes sense to translate them (and they won’t be featured in the quiz anyways).

[1]: https://re-publica.com/de/session/strange-obscure-and-interesting-facts-wikipedia-quiz