### PR TITLE
Replace two slow queries with static data

### DIFF
--- a/datenpumpe-server/queries.php
+++ b/datenpumpe-server/queries.php
@@ -121,62 +121,97 @@ SPARQL
     'title' => 'Most inherited professions',
     'query' => <<<SPARQL
 #defaultView:BubbleChart
-SELECT ?occupation ?occupationLabel ?count WITH {
-  SELECT ?occupation (COUNT(DISTINCT ?person1) AS ?count) WHERE {
-    wd:Q5 ^wdt:P31 ?person1, ?person2, ?person3, ?person4, ?person5.
-    ?person1 wdt:P22|wdt:P25 ?person2.
-    ?person2 wdt:P22|wdt:P25 ?person3.
-    ?person3 wdt:P22|wdt:P25 ?person4.
-    ?person4 wdt:P22|wdt:P25 ?person5.
-    
-    ?occupation ^wdt:P106 ?person1, ?person2, ?person3, ?person4, ?person5.
+SELECT ?occupation ?occupationLabel ?count WHERE {
+  VALUES (?occupation ?occupationLabel ?count) {
+    (<http://www.wikidata.org/entity/Q6606110> "industrialist"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1415090> "film score composer"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q593362> "draper"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1937431> "organ builder"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1941338> "burgess"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q16387970> "Q16387970" "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q66495020> "estate owner"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q11620114> "kadōka"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q189290> "military officer"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q947305> "skald"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q81096> "engineer"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q639669> "musician"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q16533> "judge"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q11900058> "explorer"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q4122737> "Vogt"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q593644> "chemist"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q11063> "astronomer"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q2259451> "stage actor"@en "1"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q482980> "author"@en "2"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q219477> "missionary"@en "2"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q11513337> "athletics competitor"@en "2"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q955464> "parson"@en "2"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1622272> "university teacher"@en "2"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1234713> "theologian"@en "2"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q211423> "goldsmith"@en "2"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q193391> "diplomat"@en "2"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q500251> "ship-owner"@en "2"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q765778> "organist"@en "2"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1416611> "postmaster"@en "2"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q512314> "socialite"@en "2"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q372436> "statesperson"@en "2"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1463475> "mintmaster"@en "3"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1688932> "jiedushi"@en "3"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q12826225> "Lord"@en "3"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q36180> "writer"@en "3"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q715222> "lady-in-waiting"@en "3"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q2374149> "botanist"@en "3"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q618532> "landlord"@en "4"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q39631> "physician"@en "4"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q2516866> "publisher"@en "4"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q854997> "Bhikkhu"@en "4"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1402561> "military leader"@en "4"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q175151> "printer"@en "4"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q3303330> "calligrapher"@en "4"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q10732476> "art collector"@en "4"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q42973> "architect"@en "4"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1279683> "Nasi"@en "4"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q10800557> "film actor"@en "4"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q3303297> "ironmaster"@en "5"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q42603> "priest"@en "5"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q49757> "poet"@en "5"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q4964182> "philosopher"@en "6"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q102083> "knight"@en "6"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q40348> "lawyer"@en "6"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1250916> "warrior"@en "7"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1934684> "homemaker"@en "8"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q215536> "merchant"@en "8"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q40881196> "printer-bookseller"@en "10"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1483709> "land owner"@en "10"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q131524> "entrepreneur"@en "11"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q2928765> "busshi"@en "12"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1281618> "sculptor"@en "12"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q3519259> "count"@en "14"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q36834> "composer"@en "15"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q12097> "king"@en "16"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q844586> "gentry"@en "17"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q43845> "businessperson"@en "17"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q131512> "farmer"@en "20"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q48146261> "kabuki actor"@en "22"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q133485> "rabbi"@en "24"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q16744001> "noble"@en "30"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q33999> "actor"@en "30"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1028181> "painter"@en "36"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q806798> "banker"@en "46"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q47064> "military personnel"@en "48"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q38142> "samurai"@en "49"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q273108> "condottiero"@en "55"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q98103687> "Ancient Roman military personnel"@en "64"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q11545923> "military commander"@en "74"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1975935> "bushi"@en "80"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1409420> "feudatory"@en "83"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q97667506> "Ancient Roman politician"@en "103"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1097498> "ruler"@en "109"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q1062083> "billionaire"@en "131"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q2304859> "sovereign"@en "158"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q116> "monarch"@en "265"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q2478141> "aristocrat"@en "1061"^^<http://www.w3.org/2001/XMLSchema#integer>)
+    (<http://www.wikidata.org/entity/Q82955> "politician"@en "2081"^^<http://www.w3.org/2001/XMLSchema#integer>)
   }
-  GROUP BY ?occupation ?occupationLabel
-} AS %results WHERE {
-  INCLUDE %results  .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
-}
-SPARQL
-  ],
-
-
-  [
-    'type' => 'images',
-    'title' => 'Selection of early women’s art',
-    'query' => <<<SPARQL
-#defaultView:ImageGrid
-SELECT ?image ?artistLabel ?artLabel ?date WHERE {
-  {
-    SELECT (SAMPLE(?image) AS ?image) ?artist ?art (YEAR(MIN(?date)) AS ?date) WHERE {
-    ?art wdt:P170 ?artist;
-           wdt:P18 ?image;
-           wdt:P571 ?date.
-      ?artist wdt:P31 wd:Q5.
-      { ?artist wdt:P21 wd:Q6581072. } UNION { ?artist wdt:P21 wd:Q1052281. } # using ?artist wdt:P21/wdt:P279? wd:Q6581072 instead would be nice, but is unfortunately too inefficient
-    }
-    GROUP BY ?artist ?art
-    ORDER BY ASC(?date)
-    LIMIT 20
-  }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
-}
-ORDER BY MD5(CONCAT(STR(NOW()), STR(?art))) # simulate random order – ORDER BY RAND() doesn’t have the desired effect
-LIMIT 20
-SPARQL
-  ],
-
-
-  [
-    'type' => 'map',
-    'title' => 'Auf "ing" endende Ortschaften in Deutschland',
-    'query' => <<<SPARQL
-#defaultView:Map
-SELECT ?item ?name ?itemCoords WHERE {
-  ?item wdt:P31 wd:Q262166;
-        rdfs:label ?name.
-  FILTER(LANG(?name) = "de")
-  FILTER(STRENDS(?name, "ing"@de))
-  ?item wdt:P625 ?itemCoords.
 }
 SPARQL
   ],
@@ -278,49 +313,65 @@ SPARQL
     'query' => <<<SPARQL
 # UK parliaments with count of Johns and count of women
 #defaultView:LineChart
-SELECT ?date ?count ?label WITH {
-  # all MPs with their associated parliament
-  SELECT DISTINCT ?mp ?parliament WHERE {
-    ?mp wdt:P31 wd:Q5.
-    {
-      # new data model: position held – Member of the nth Parliament of the United Kingdom
-      ?mp p:P39/ps:P39 ?position.
-      ?position wdt:P279 wd:Q16707842;
-                p:P279/pq:P2937|wdt:P2937 ?parliament.
-    } UNION {
-      # old data model: member of – nth Parliament of the United Kingdom
-      ?mp p:P463/ps:P463 ?parliament.
-      ?parliament wdt:P31 wd:Q21094819.
-    }
+SELECT ?date ?count ?label WHERE {
+  VALUES (?date ?count ?label) {
+    ("1919-02-11T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "79"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1919-02-11T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "3"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1922-11-23T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "3"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1922-11-23T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "60"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1924-01-15T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "50"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1924-01-15T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "8"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1924-12-09T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "51"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1924-12-09T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "10"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1929-07-02T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "52"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1929-07-02T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "16"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1931-11-10T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "57"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1931-11-10T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "15"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1935-12-03T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "76"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1935-12-03T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "15"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1945-08-15T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "56"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1945-08-15T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "26"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1950-03-06T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "52"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1950-03-06T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "21"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1951-11-06T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "21"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1951-11-06T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "53"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1955-06-09T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "63"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1955-06-09T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "28"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1959-10-27T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "74"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1959-10-27T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "26"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1964-11-03T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "29"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1964-11-03T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "55"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1966-04-21T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "58"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1966-04-21T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "28"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1970-07-02T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "62"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1970-07-02T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "28"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1974-03-12T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "23"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1974-03-12T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "60"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1974-10-29T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "66"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1974-10-29T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "28"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1979-05-15T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "68"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1979-05-15T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "23"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1983-06-22T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "62"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1983-06-22T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "28"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1987-06-25T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "44"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1987-06-25T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "61"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1992-05-06T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "65"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("1992-05-06T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "56"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1997-05-14T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "47"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("1997-05-14T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "122"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("2001-06-20T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "119"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("2001-06-20T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "43"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("2005-05-17T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "129"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("2005-05-17T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "41"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("2010-05-25T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "25"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("2010-05-25T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "149"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("2015-05-27T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "20"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("2015-05-27T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "197"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("2017-06-21T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "20"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("2017-06-21T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "213"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
+    ("2019-12-19T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "19"^^<http://www.w3.org/2001/XMLSchema#integer> "Johns"@en)
+    ("2019-12-19T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> "229"^^<http://www.w3.org/2001/XMLSchema#integer> "women"@en)
   }
-} AS %MPsWithParliament WITH {
-  # count of Johns in each parliament
-  SELECT ?parliament (COUNT(DISTINCT ?mp) AS ?johns) WHERE {
-    INCLUDE %MPsWithParliament.
-    ?mp wdt:P735 wd:Q4925477.
-  }
-  GROUP BY ?parliament
-} AS %johns WITH {
-  # count of women in each parliament
-  SELECT ?parliament (COUNT(DISTINCT ?mp) AS ?women) WHERE {
-    INCLUDE %MPsWithParliament.
-    ?mp wdt:P21/wdt:P279* wd:Q6581072. # (P279*: include transgender women – none yet, but will probably happen in the future)
-  }
-  GROUP BY ?parliament
-} AS %women WHERE {
-  # get ?johns and ?women
-  INCLUDE %johns.
-  INCLUDE %women.
-  # fan out single result
-  # ?parliament ?johns ?women
-  # into two results
-  # ?parliament "Johns" ?johns
-  # ?parliament "women" ?women
-  # so the line chart works
-  VALUES ?label { "Johns"@en "women"@en }
-  BIND(IF(?label = "Johns"@en, ?johns, ?women) AS ?count)
-  # get parliament date for the chart
-  ?parliament wdt:P571|wdt:P580 ?date
 }
 SPARQL
   ],

--- a/datenpumpe-server/queries.php
+++ b/datenpumpe-server/queries.php
@@ -16,7 +16,7 @@ $queries = [
 
   [
     'type' => 'table',
-    'title' => 'Wieviele Päpste hatten wieviele Kinder?',
+    'title' => 'How many popes had how many children?',
     'query' => <<<SPARQL
 SELECT ?Papst (YEAR(?date) AS ?geboren) (COUNT(?child) as ?Kinder) WHERE {
   ?child wdt:P22 ?father.
@@ -25,7 +25,7 @@ SELECT ?Papst (YEAR(?date) AS ?geboren) (COUNT(?child) as ?Kinder) WHERE {
   wdt:P569 ?date.
   OPTIONAL { ?father wdt:P18 ?picture. }
   ?father rdfs:label ?Papst.
-  FILTER(LANG(?Papst) = 'de').
+  FILTER(LANG(?Papst) = 'en').
 }
 GROUP BY ?Papst ?date
 ORDER BY DESC(?Kinder) ?Papst
@@ -35,7 +35,7 @@ SPARQL
 
   [
     'type' => 'images',
-    'title' => 'Welche Nationalflaggen zeigen Sterne?',
+    'title' => 'Which national flags show stars?',
     'query' => <<<SPARQL
 SELECT DISTINCT ?flag ?flagLabel (MIN(?images) AS ?image) WHERE {
   ?flag wdt:P31/wdt:P279* wd:Q186516;
@@ -43,7 +43,7 @@ SELECT DISTINCT ?flag ?flagLabel (MIN(?images) AS ?image) WHERE {
   ?flag wdt:P18 ?images.
   VALUES ?astronomical { wd:Q8928 wd:Q523 } ?depicted wdt:P31?/wdt:P279* ?astronomical.
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "de".
+    bd:serviceParam wikibase:language "en".
     ?flag rdfs:label ?flagLabel.
     ?depicted rdfs:label ?depictedLabel.
   }
@@ -56,7 +56,7 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Nur 12 internationale Flughäfen sind nach Frauen benannt',
+    'title' => 'Only 25 international airports are named after women',
     'query' => <<<SPARQL
 SELECT ?airport ?airportLabel ?location ?person ?personLabel (?gender AS ?layer) WHERE {
   ?airport wdt:P31/wdt:P279* wd:Q1248784;
@@ -79,7 +79,7 @@ SELECT ?airport ?airportLabel ?location ?person ?personLabel (?gender AS ?layer)
     BIND("other"@en AS ?other)
   }
   BIND(COALESCE(?female, ?male, ?other, "unknown"@en) AS ?gender)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 SPARQL
   ],
@@ -87,7 +87,7 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Nach Frauen benannte Hochschulen',
+    'title' => 'Higher education institutions named after women',
     'query' => <<<SPARQL
 SELECT ?airport ?airportLabel ?location ?person ?personLabel (?gender AS ?layer) WHERE {
   ?airport wdt:P31/wdt:P279* wd:Q38723;
@@ -110,7 +110,7 @@ SELECT ?airport ?airportLabel ?location ?person ?personLabel (?gender AS ?layer)
     BIND("other"@en AS ?other)
   }
   BIND(COALESCE(?female, ?male, ?other, "unknown"@en) AS ?gender)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 SPARQL
   ],
@@ -118,7 +118,7 @@ SPARQL
 
   [
     'type' => 'embed',
-    'title' => 'Meistvererbte Berufe',
+    'title' => 'Most inherited professions',
     'query' => <<<SPARQL
 #defaultView:BubbleChart
 SELECT ?occupation ?occupationLabel ?count WITH {
@@ -134,7 +134,7 @@ SELECT ?occupation ?occupationLabel ?count WITH {
   GROUP BY ?occupation ?occupationLabel
 } AS %results WHERE {
   INCLUDE %results  .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 SPARQL
   ],
@@ -142,7 +142,7 @@ SPARQL
 
   [
     'type' => 'images',
-    'title' => 'Auswahl früher Kunst von Frauen',
+    'title' => 'Selection of early women’s art',
     'query' => <<<SPARQL
 #defaultView:ImageGrid
 SELECT ?image ?artistLabel ?artLabel ?date WHERE {
@@ -158,7 +158,7 @@ SELECT ?image ?artistLabel ?artLabel ?date WHERE {
     ORDER BY ASC(?date)
     LIMIT 20
   }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 ORDER BY MD5(CONCAT(STR(NOW()), STR(?art))) # simulate random order – ORDER BY RAND() doesn’t have the desired effect
 LIMIT 20
@@ -216,7 +216,7 @@ SPARQL
 
   [
     'type' => 'singleValue',
-    'title' => 'Wie alt sind Mitglieder des 20. Bundestags durchschnittlich?',
+    'title' => 'How old are members of the 20th Bundestag on average?',
     'query' => <<<SPARQL
 SELECT (AVG(?age) AS ?avgAge) WHERE {
 ?mdb wdt:P31 wd:Q5;
@@ -233,7 +233,7 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Sprachverteilung in der Schweiz',
+    'title' => 'Language distribution in Switzerland',
     'query' => <<<SPARQL
 #defaultView:Map
   SELECT ?item (SAMPLE(?title) AS ?itemLabel) (SAMPLE(?location) AS ?location) (SAMPLE(?language) AS ?layer)
@@ -274,7 +274,7 @@ SPARQL
 
   [
     'type' => 'embed',
-    'title' => 'Anteil von Frauen und Johns im britischen Parlament',
+    'title' => 'Number of women and Johns in British parliaments',
     'query' => <<<SPARQL
 # UK parliaments with count of Johns and count of women
 #defaultView:LineChart
@@ -328,7 +328,7 @@ SPARQL
 
   [
     'type' => 'table',
-    'title' => 'Frauenanteil in fiktiven Universen',
+    'title' => 'Ratio of female characters per fictional universe',
     'query' => <<<SPARQL
 # ratio of female characters per fictional universe
 # (assuming that any item with “from fictional universe” and “sex or gender” is a fictional character)
@@ -344,7 +344,7 @@ SELECT ?universeLabel (?percentString AS ?Anteil) (?females AS ?Frauen) (?total 
   BIND(?females/?total AS ?ratio)
   BIND(100*?ratio AS ?percent)
   BIND(CONCAT(SUBSTR(STR(?percent), 1, 5), "%") AS ?percentString)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 ORDER BY DESC(?total)
 LIMIT 20
@@ -354,7 +354,7 @@ SPARQL
 
   [
     'type' => 'table',
-    'title' => 'Daten zu bekannten Katzen',
+    'title' => 'Data about famous cats',
     'query' => <<<SPARQL
 SELECT ?cat ?catLabel ?catDescription (YEAR(?date) as ?born) (GROUP_CONCAT(?ownerLabel; SEPARATOR=", ") AS ?owner)
 WHERE {
@@ -363,7 +363,7 @@ WHERE {
   ?cat wdt:P127 ?ownerItem.
   ?ownerItem rdfs:label ?ownerLabel.
   FILTER(LANG(?ownerLabel) = 'en').
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
 }
 GROUP BY ?cat ?catLabel ?catDescription ?date
 ORDER BY MD5(CONCAT(STR(NOW()), STR(?item)))
@@ -374,7 +374,7 @@ SPARQL
 
   [
     'type' => 'table',
-    'title' => 'Welche großen Städte liegen am tiefsten?',
+    'title' => 'Which big cities are located lowest on Earth?',
     'query' => <<<SPARQL
 SELECT ?cityLabel ?countryLabel ?altitude ?population WHERE
 {
@@ -382,7 +382,7 @@ SELECT ?cityLabel ?countryLabel ?altitude ?population WHERE
     wdt:P2044 ?altitude ;
     wdt:P17 ?country ;
     wdt:P1082 ?population .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
 }
 ORDER BY ?altitude ?cityLabel
 LIMIT 19
@@ -392,7 +392,7 @@ SPARQL
 
   [
     'type' => 'table',
-    'title' => 'Welche großen Städte liegen am höchsten?',
+    'title' => 'Which big cities are located highest on Earth?',
     'query' => <<<SPARQL
 SELECT ?cityLabel ?countryLabel ?altitude ?population WHERE
 {
@@ -400,7 +400,7 @@ SELECT ?cityLabel ?countryLabel ?altitude ?population WHERE
     wdt:P2044 ?altitude ;
     wdt:P17 ?country ;
     wdt:P1082 ?population .
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en" }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
 }
 ORDER BY DESC(?altitude) ?cityLabel
 LIMIT 19
@@ -410,7 +410,7 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Kohlekraftwerke in Deutschland',
+    'title' => 'Coal power plants in Germany',
     'query' => <<<SPARQL
 #defaultView:Map
 SELECT DISTINCT ?item ?itemLabel ?image ?coor
@@ -420,7 +420,7 @@ SELECT DISTINCT ?item ?itemLabel ?image ?coor
       wdt:P625 ?coor.
   FILTER NOT EXISTS { ?item wdt:P576 ?closed. }
   FILTER NOT EXISTS { ?item wdt:P582 ?enddate. }
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 SPARQL
   ],
@@ -428,7 +428,7 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Offshore-Windparks in Europa',
+    'title' => 'Offshore wind farms in Europe',
     'query' => <<<SPARQL
 #defaultView:Map
 SELECT DISTINCT ?item ?coor
@@ -449,7 +449,7 @@ SPARQL
   /**
   [
     'type' => 'embed',
-    'title' => 'Tragezeiten von Säugetieren',
+    'title' => 'Gestation periods of mammals',
     'query' => <<<SPARQL
 # Average gestation period of genera, color-coded by order
 #defaultView:BubbleChart
@@ -457,7 +457,7 @@ SPARQL
 WHERE
 {
   {
-    BIND("[AUTO_LANGUAGE]" AS ?language)
+    BIND("en" AS ?language)
     # find species with gestation period normalized to seconds
     ?species p:P3063/psn:P3063/wikibase:quantityAmount ?periodSeconds.
   # convert to days
@@ -474,7 +474,7 @@ WHERE
     ?genus rdfs:label ?genusLabel.
     FILTER(LANG(?genusLabel) = ?language)
     }
-    BIND(COALESCE(?trivialName, ?genusLabel, "<kein Name>"@de) AS ?label)
+    BIND(COALESCE(?trivialName, ?genusLabel, "<no name>"@en) AS ?label)
     # find order
     ?genus wdt:P171* ?order.
     ?order wdt:P105 wd:Q36602.
@@ -485,11 +485,11 @@ WHERE
   {
     # add scale
     VALUES (?genus ?period ?label) {
-    (wd:Q23387 7 "Woche"@de)
-      (wd:Q5151 30.436875 "Monat"@de)
-      (wd:Q1643308 91.310625 "3 Monate"@de)
-      (wd:Q2269240 182.62125 "6 Monate"@de)
-      (wd:Q577 365.2425 "Jahr"@de)
+    (wd:Q23387 7 "week"@en)
+      (wd:Q5151 30.436875 "month"@en)
+      (wd:Q1643308 91.310625 "3 months"@en)
+      (wd:Q2269240 182.62125 "6 months"@en)
+      (wd:Q577 365.2425 "year"@en)
     }
     BIND("CCCCCC" AS ?rgb)
   }
@@ -501,7 +501,7 @@ SPARQL
 
   [
     'type' => 'embed',
-    'title' => 'Kinder von Dschingis Khan',
+    'title' => 'Genghis Khan\'s children',
     'query' => <<<SPARQL
 #Children of Genghis Khan
 #defaultView:Graph
@@ -521,7 +521,7 @@ SELECT ?item ?itemLabel ?pic ?linkTo
   }
   OPTIONAL { ?item wdt:P40 ?linkTo }
   OPTIONAL { ?item wdt:P18 ?pic }
-  SERVICE wikibase:label {bd:serviceParam wikibase:language "de,en" }
+  SERVICE wikibase:label {bd:serviceParam wikibase:language "en" }
 }
 SPARQL
   ],
@@ -529,14 +529,14 @@ SPARQL
 
   [
     'type' => 'images',
-    'title' => 'Benannt nach Nelson Mandela',
+    'title' => 'Named after Nelson Mandela',
     'query' => <<<SPARQL
 SELECT ?label ?image ?loc WHERE {
   ?item wdt:P138 wd:Q8023.
   ?item wdt:P18 ?image.
   ?item wdt:P131 ?location.
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "de,en" . 
+    bd:serviceParam wikibase:language "en" . 
     ?item rdfs:label ?label.
     ?location rdfs:label ?loc.
   }
@@ -548,7 +548,7 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Wo wurden Raumfahrerinnen und Raumfahrer geboren?',
+    'title' => 'Where were astronauts born?',
     'query' => <<<SPARQL
 SELECT ?astronaut ?coord (?genderlabel AS ?layer) WHERE {
   ?astronaut ?x1 wd:Q11631;
@@ -557,7 +557,7 @@ SELECT ?astronaut ?coord (?genderlabel AS ?layer) WHERE {
   wdt:P19 ?birthplace.
   ?birthplace wdt:P625 ?coord.
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "de,en" . 
+    bd:serviceParam wikibase:language "en" . 
     ?gender rdfs:label ?genderlabel.
   }
 }
@@ -568,7 +568,7 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'U-Bahnhöfe in Berlin',
+    'title' => 'U-Bahn stations in Berlin',
     'query' => <<<SPARQL
   SELECT ?coord (?label AS ?layer)
 WHERE {
@@ -577,7 +577,7 @@ WHERE {
           wdt:P81 ?line;
           wdt:P625 ?coord.
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "de,en" . 
+    bd:serviceParam wikibase:language "en,de" . 
     ?line rdfs:label ?label.
   }
 }
@@ -588,14 +588,14 @@ SPARQL
 
   [
     'type' => 'embed',
-    'title' => 'Anzahl der Bahnlinien',
+    'title' => 'Number of train lines',
     'query' => <<<SPARQL
 #defaultView:BubbleChart
 SELECT ?country ?countryLabel (COUNT(?station) AS ?stations)
 WHERE {
   ?station wdt:P31/wdt:P279* wd:Q15141321;
              wdt:P17 ?country;
-    SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],de" }
+    SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
 }
 GROUP BY ?country ?countryLabel
 SPARQL
@@ -604,7 +604,7 @@ SPARQL
 
   [
     'type' => 'singleValue',
-    'title' => 'Anzahl der Tierarten in Wikidata',
+    'title' => 'Number of species in Wikidata',
     'query' => <<<SPARQL
 SELECT (COUNT(?item) as ?count)
 WHERE {
@@ -616,7 +616,7 @@ SPARQL
 
   [
     'type' => 'singleValue',
-    'title' => 'Anzahl der Personen in Wikidata',
+    'title' => 'Number of people in Wikidata',
     'query' => <<<SPARQL
 SELECT (COUNT(?item) as ?count)
 WHERE {
@@ -628,14 +628,14 @@ SPARQL
 
   [
     'type' => 'images',
-    'title' => 'Benannt nach Nelson Mandela',
+    'title' => 'named after Nelson Mandela',
     'query' => <<<SPARQL
 SELECT ?label ?image ?loc WHERE {
   ?item wdt:P138 wd:Q8023.
   ?item wdt:P18 ?image.
   ?item wdt:P131 ?location.
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "de,en" . 
+    bd:serviceParam wikibase:language "en" . 
     ?item rdfs:label ?label.
     ?location rdfs:label ?loc.
   }
@@ -647,7 +647,7 @@ SPARQL
 
   [
     'type' => 'embed',
-    'title' => 'Herkunft von Nobelpreisträgern',
+    'title' => 'origin of Nobel Prize winners',
     'query' => <<<SPARQL
 #defaultView:BubbleChart
 SELECT ?CountryLabel (COUNT(?Person) AS ?Preisträger)
@@ -658,7 +658,7 @@ WHERE
           wdt:P19 ?Place .
   ?Place wdt:P17 ?Country .
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
+    bd:serviceParam wikibase:language "en" .
   }
 }
 GROUP BY ?CountryLabel
@@ -669,13 +669,13 @@ SPARQL
 
   [
     'type' => 'images',
-    'title' => 'Gemälde im Louvre',
+    'title' => 'paintings in the Louvre',
     'query' => <<<SPARQL
 SELECT ?label ?image WHERE {
   ?item wdt:P195 wd:Q3044768 .
   ?item wdt:P18 ?image .
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "de,en" . 
+    bd:serviceParam wikibase:language "en" . 
     ?item rdfs:label ?label .
   }
 }
@@ -686,7 +686,7 @@ SPARQL
 
   [
     'type' => 'embed',
-    'title' => 'Zeitleiste der Raumsonden',
+    'title' => 'Timeline of space probes',
     'query' => <<<SPARQL
 #defaultView:Timeline
   SELECT ?image ?launchdate ?itemLabel
@@ -695,7 +695,7 @@ SPARQL
   ?item wdt:P31 wd:Q26529 .
    ?item wdt:P619 ?launchdate .
   OPTIONAL { ?item wdt:P18 ?image }
-   SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en". }
+   SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 SPARQL
   ],
@@ -703,14 +703,14 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Steckdosentypen weltweit',
+    'title' => 'Electrical socket types around the world',
     'query' => <<<SPARQL
 SELECT ?geoshape ?coord (?plugLabel AS ?layer) WHERE {
   ?country wdt:P2853 ?plug ;
            wdt:P3896 ?geoshape ;
            wdt:P625 ?coord .
   SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "de,en" .
+    bd:serviceParam wikibase:language "en" .
     ?plug rdfs:label ?plugLabel.
   }
 }
@@ -721,7 +721,7 @@ SPARQL
 
   [
     'type' => 'embed',
-    'title' => 'Länge von Filmen nach Datum',
+    'title' => 'Duration of films over time',
     'query' => <<<SPARQL
 #defaultView:LineChart
 SELECT ?year (AVG(?durationInMinutes) AS ?avgDurationInMinutes) ?genreLabel WHERE {
@@ -741,7 +741,7 @@ SELECT ?year (AVG(?durationInMinutes) AS ?avgDurationInMinutes) ?genreLabel WHER
   FILTER(?durationInMinutes < 60*24) # I take the editorial liberty to exclude these films (some stupidly long documentaries), because they just absurdly skew the averages
   BIND(STR(YEAR(?date)) AS ?year)
   BIND(?durationInSeconds/60 AS ?durationInMinutes)
-  SERVICE wikibase:label { bd:serviceParam wikibase:language "de,en". }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
 GROUP BY ?year ?genreLabel
 HAVING(COUNT(DISTINCT ?film) >= 10)
@@ -752,17 +752,17 @@ SPARQL
 
   [
     'type' => 'map',
-    'title' => 'Erdbeben und Kernkraftwerke',
+    'title' => 'Earthquakes and nuclear power stations',
     'query' => <<<SPARQL
 SELECT ?event ?eventLabel ?coordinates ?layer WHERE {
   {
     ?event wdt:P31/wdt:P279* wd:Q7944;
                 wdt:P625 ?coordinates.
-    BIND("Erdbeben"@de AS ?layer)
+    BIND("earthquake"@en AS ?layer)
   } UNION {
     ?event wdt:P31/wdt:P279* wd:Q134447;
            wdt:P625 ?coordinates.
-    BIND("Kernkraftwerk"@de AS ?layer)
+    BIND("nuclear power station"@en AS ?layer)
   }
 }
 SPARQL


### PR DESCRIPTION
The two queries for “most inherited professions” and “number of women and Johns in British parliaments” are very slow and can sometimes even time out. This isn’t really a problem when using the real data pump, because it doesn’t run queries live during pumping; however, when we’re thinking of using the datenpumpe website directly at re:publica, it’s more important that these queries are fast, so replace them with a static result set temporarily. (This will be reverted later.)

---

(Based on #12 to avoid merge conflicts, so that PR should be merged before this one.)